### PR TITLE
More memory efficient way of getting the data

### DIFF
--- a/src/CsvFileHandler.php
+++ b/src/CsvFileHandler.php
@@ -196,19 +196,19 @@ class CsvFileHandler
      * @internal
      */
     protected function parseFile(){
-        $data = file($this->getFilename());
+        $fp = fopen($this->getFilename(), 'r');
 
         $headers = null;
         if($this->getHeaderRow()) {
-            $headerLine = array_shift($data);
-            $headers = str_getcsv($headerLine, $this->getDelimiter(), $this->getEnclosure(), $this->getEscape());
+            $headers = fgetcsv($fp, null, $this->getDelimiter(), $this->getEnclosure(), $this->getEscape());
         }
 
-        foreach($data as $line){
-            $values = str_getcsv($line, $this->getDelimiter(), $this->getEnclosure(), $this->getEscape());
+        while ($values = fgetcsv($fp, null, $this->getDelimiter(), $this->getEnclosure(), $this->getEscape())) {
             $record = new RecordObject($headers, $values);
             $this->addRecord($record);
         }
+
+        fclose($fp);
 
     }
 }


### PR DESCRIPTION
When you run file($this->getFilename()) it grabs the entire file into memory. After that you loop over the file and then copy it into the Object space created by addRecord. 

So, if you have a 100 MB file, you're using at least 200 MB before the file is in object space (that's if the objects are the same size line for line).

So replacing the file($this->getFilename()) with $fp = fopen($this->getFilename(), 'r'); and using the pointer to get line by line you side-step the 100MB initial input into memory. 
